### PR TITLE
Corrige agrupamento do output final, adicionando group by [<kind>][<name>]

### DIFF
--- a/groupResources/groupByKind/outputs.tf
+++ b/groupResources/groupByKind/outputs.tf
@@ -7,7 +7,7 @@ locals {
 
 output "kinds" {
   value = {
-    for kind, result in local.kinds : kind => {
+    for kind in local.kinds : kind => {
       for resource in var.resources : resource.metadata.name => resource
       if resource.apiGroup == var.apiGroup && resource.kind == kind
     }

--- a/tests/test_output_by_apigroup.tftest.hcl
+++ b/tests/test_output_by_apigroup.tftest.hcl
@@ -16,4 +16,25 @@ run "valida_output_por_apigroup" {
     condition     = length(keys(module.groupResources.groupedResources)) == 1
     error_message = "Deveria haver apenas um apigroup: gcp.iam"
   }
+
+}
+
+run "valida_output_por_kind" {
+  command = plan
+  variables {
+    yamls = [
+      "tests/fixtures/user.gcp.iam.crd.yaml",
+      "tests/fixtures/user.gcp.iam.manifest.yaml",
+    ]
+  }
+
+
+  assert {
+    condition = length(
+      keys(
+        try(module.groupResources.groupedResources["gcp.iam"]["User"], {})
+      )
+    ) == 2
+    error_message = "Não agrupou pelo kind User"
+  }
 }


### PR DESCRIPTION
O output desse module não deveria ter também o argupamento por kind?

Isso é o que está sendo retornado por ele:
![Captura de tela de 2024-09-21 12-50-06](https://github.com/user-attachments/assets/b60dd5f3-4730-4dd5-b49f-831fe9034e83)

E olhando o [output final](https://github.com/lukerops/manifest.tf/blob/main/outputs.tf#L7-L9) do módulo raiz
```
output "resources" {
  value = module.groupResources.groupedResources
}
```

ele referencia exatamente o output do module.groupResources.