### PR TITLE
Movendo testes do CustomResourceDefinition/v1alpha1 para a pasta raiz

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,16 +26,8 @@ jobs:
 
       - name: Terraform init (v${{matrix.terraform_version}})
         run: |
-          for i in $(find . -name tests -exec dirname {} \;); do
-            echo "Running tests for: \"$i\""
-            terraform -chdir="$i" init
-            echo;
-          done
+          terraform init
 
       - name: Run Tests
         run: |
-          for i in $(find . -name tests -exec dirname {} \;); do
-            echo "Running tests for: \"$i\""
-            terraform -chdir="$i" test
-            echo;
-          done
+          terraform test

--- a/tests/CustomResourceDefinition_v1alpha1.tftest.hcl
+++ b/tests/CustomResourceDefinition_v1alpha1.tftest.hcl
@@ -1,5 +1,8 @@
 run "missing_group" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/"
+  }
 
   variables {
     path = "."
@@ -18,6 +21,9 @@ run "missing_group" {
 
 run "missing_kind" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/"
+  }
 
   variables {
     path = "."
@@ -38,6 +44,9 @@ run "missing_kind" {
 
 run "missing_versions" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/"
+  }
 
   variables {
     path = "."
@@ -59,6 +68,9 @@ run "missing_versions" {
 
 run "with_invalid_versions" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/"
+  }
 
   variables {
     path = "."
@@ -82,6 +94,9 @@ run "with_invalid_versions" {
 
 run "with_valid_versions" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/"
+  }
 
   variables {
     path = "."

--- a/tests/CustomResourceDefinition_v1alpha1_array.tftest.hcl
+++ b/tests/CustomResourceDefinition_v1alpha1_array.tftest.hcl
@@ -1,5 +1,8 @@
 run "without_items" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/array/"
+  }
 
   variables {
     metadata_name = "test"
@@ -17,6 +20,9 @@ run "without_items" {
 
 run "without_minItems_and_maxItems_and_with_bool_items" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/array/"
+  }
 
   variables {
     metadata_name = "test"
@@ -51,6 +57,9 @@ run "without_minItems_and_maxItems_and_with_bool_items" {
 
 run "without_minItems_and_maxItems_and_with_string_items" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/array/"
+  }
 
   variables {
     metadata_name = "test"
@@ -89,6 +98,9 @@ run "without_minItems_and_maxItems_and_with_string_items" {
 
 run "without_minItems_and_maxItems_and_with_integer_items" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/array/"
+  }
 
   variables {
     metadata_name = "test"
@@ -127,6 +139,9 @@ run "without_minItems_and_maxItems_and_with_integer_items" {
 
 run "without_minItems_and_maxItems_and_with_reduced_object_items" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/array/"
+  }
 
   variables {
     metadata_name = "test"
@@ -177,6 +192,9 @@ run "without_minItems_and_maxItems_and_with_reduced_object_items" {
 
 run "with_minItems" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/array/"
+  }
 
   variables {
     metadata_name = "test"
@@ -212,6 +230,9 @@ run "with_minItems" {
 
 run "with_minLength_and_maxItems" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/array/"
+  }
 
   variables {
     metadata_name = "test"
@@ -248,6 +269,9 @@ run "with_minLength_and_maxItems" {
 
 run "with_invalid_minItems_and_maxItems" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/array/"
+  }
 
   variables {
     metadata_name = "test"
@@ -270,6 +294,9 @@ run "with_invalid_minItems_and_maxItems" {
 
 run "with_string_minItems" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/array/"
+  }
 
   variables {
     metadata_name = "test"
@@ -291,6 +318,9 @@ run "with_string_minItems" {
 
 run "with_string_maxItems" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/array/"
+  }
 
   variables {
     metadata_name = "test"
@@ -312,6 +342,9 @@ run "with_string_maxItems" {
 
 run "with_invalid_minItems_value" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/array/"
+  }
 
   variables {
     metadata_name = "test"
@@ -333,6 +366,9 @@ run "with_invalid_minItems_value" {
 
 run "with_invalid_maxItems_value" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/array/"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/CustomResourceDefinition_v1alpha1_integer.tftest.hcl
+++ b/tests/CustomResourceDefinition_v1alpha1_integer.tftest.hcl
@@ -1,5 +1,8 @@
 run "without_minimum_and_maximum" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/integer"
+  }
 
   variables {
     metadata_name = "test"
@@ -26,6 +29,9 @@ run "without_minimum_and_maximum" {
 
 run "with_minimum" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/integer"
+  }
 
   variables {
     metadata_name = "test"
@@ -53,6 +59,9 @@ run "with_minimum" {
 
 run "with_minimum_and_maximum" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/integer"
+  }
 
   variables {
     metadata_name = "test"
@@ -81,6 +90,9 @@ run "with_minimum_and_maximum" {
 
 run "with_invalid_minimum_and_maximum" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/integer"
+  }
 
   variables {
     metadata_name = "test"
@@ -100,6 +112,9 @@ run "with_invalid_minimum_and_maximum" {
 
 run "with_string_minimum" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/integer"
+  }
 
   variables {
     metadata_name = "test"
@@ -118,6 +133,9 @@ run "with_string_minimum" {
 
 run "with_string_maximum" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/integer"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/CustomResourceDefinition_v1alpha1_object.tftest.hcl
+++ b/tests/CustomResourceDefinition_v1alpha1_object.tftest.hcl
@@ -1,5 +1,8 @@
 run "without_properties" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/object"
+  }
 
   variables {
     metadata_name = "test"
@@ -17,6 +20,9 @@ run "without_properties" {
 
 run "with_invalid_properties" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/object"
+  }
 
   variables {
     metadata_name = "test"
@@ -35,6 +41,9 @@ run "with_invalid_properties" {
 
 run "with_properties_missing_type" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/object"
+  }
 
   variables {
     metadata_name = "test"
@@ -55,6 +64,9 @@ run "with_properties_missing_type" {
 
 run "with_properties_invalid_type" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/object"
+  }
 
   variables {
     metadata_name = "test"
@@ -77,6 +89,9 @@ run "with_properties_invalid_type" {
 
 run "with_properties" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/object"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/CustomResourceDefinition_v1alpha1_reduced_array.tftest.hcl
+++ b/tests/CustomResourceDefinition_v1alpha1_reduced_array.tftest.hcl
@@ -1,5 +1,8 @@
 run "without_items" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_array"
+  }
 
   variables {
     metadata_name = "test"
@@ -17,6 +20,9 @@ run "without_items" {
 
 run "without_minItems_and_maxItems_and_with_bool_items" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_array"
+  }
 
   variables {
     metadata_name = "test"
@@ -51,6 +57,9 @@ run "without_minItems_and_maxItems_and_with_bool_items" {
 
 run "without_minItems_and_maxItems_and_with_string_items" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_array"
+  }
 
   variables {
     metadata_name = "test"
@@ -89,6 +98,9 @@ run "without_minItems_and_maxItems_and_with_string_items" {
 
 run "without_minItems_and_maxItems_and_with_integer_items" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_array"
+  }
 
   variables {
     metadata_name = "test"
@@ -127,6 +139,9 @@ run "without_minItems_and_maxItems_and_with_integer_items" {
 
 run "with_minItems" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_array"
+  }
 
   variables {
     metadata_name = "test"
@@ -162,6 +177,9 @@ run "with_minItems" {
 
 run "with_minLength_and_maxItems" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_array"
+  }
 
   variables {
     metadata_name = "test"
@@ -198,6 +216,9 @@ run "with_minLength_and_maxItems" {
 
 run "with_invalid_minItems_and_maxItems" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_array"
+  }
 
   variables {
     metadata_name = "test"
@@ -220,6 +241,9 @@ run "with_invalid_minItems_and_maxItems" {
 
 run "with_string_minItems" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_array"
+  }
 
   variables {
     metadata_name = "test"
@@ -241,6 +265,9 @@ run "with_string_minItems" {
 
 run "with_string_maxItems" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_array"
+  }
 
   variables {
     metadata_name = "test"
@@ -262,6 +289,9 @@ run "with_string_maxItems" {
 
 run "with_invalid_minItems_value" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_array"
+  }
 
   variables {
     metadata_name = "test"
@@ -283,6 +313,9 @@ run "with_invalid_minItems_value" {
 
 run "with_invalid_maxItems_value" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_array"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/CustomResourceDefinition_v1alpha1_reduced_object.tftest.hcl
+++ b/tests/CustomResourceDefinition_v1alpha1_reduced_object.tftest.hcl
@@ -1,5 +1,8 @@
 run "without_properties" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_object/"
+  }
 
   variables {
     metadata_name = "test"
@@ -17,6 +20,9 @@ run "without_properties" {
 
 run "with_invalid_properties" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_object/"
+  }
 
   variables {
     metadata_name = "test"
@@ -35,6 +41,9 @@ run "with_invalid_properties" {
 
 run "with_properties_missing_type" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_object/"
+  }
 
   variables {
     metadata_name = "test"
@@ -55,6 +64,9 @@ run "with_properties_missing_type" {
 
 run "with_properties_invalid_type" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_object/"
+  }
 
   variables {
     metadata_name = "test"
@@ -77,6 +89,9 @@ run "with_properties_invalid_type" {
 
 run "with_properties" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/reduced_object/"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/CustomResourceDefinition_v1alpha1_root_object.tftest.hcl
+++ b/tests/CustomResourceDefinition_v1alpha1_root_object.tftest.hcl
@@ -1,5 +1,8 @@
 run "without_properties" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/root_object/"
+  }
 
   variables {
     metadata_name = "test"
@@ -17,6 +20,9 @@ run "without_properties" {
 
 run "with_invalid_properties" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/root_object/"
+  }
 
   variables {
     metadata_name = "test"
@@ -35,6 +41,9 @@ run "with_invalid_properties" {
 
 run "with_properties_missing_type" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/root_object/"
+  }
 
   variables {
     metadata_name = "test"
@@ -55,6 +64,9 @@ run "with_properties_missing_type" {
 
 run "with_properties_invalid_type" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/root_object/"
+  }
 
   variables {
     metadata_name = "test"
@@ -77,6 +89,9 @@ run "with_properties_invalid_type" {
 
 run "with_properties" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/root_object/"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/CustomResourceDefinition_v1alpha1_string.tftest.hcl
+++ b/tests/CustomResourceDefinition_v1alpha1_string.tftest.hcl
@@ -1,5 +1,8 @@
 run "without_minLength_and_maxLength" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/string"
+  }
 
   variables {
     metadata_name = "test"
@@ -26,6 +29,9 @@ run "without_minLength_and_maxLength" {
 
 run "with_minLength" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/string"
+  }
 
   variables {
     metadata_name = "test"
@@ -53,6 +59,9 @@ run "with_minLength" {
 
 run "with_minLength_and_maxLength" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/string"
+  }
 
   variables {
     metadata_name = "test"
@@ -81,6 +90,9 @@ run "with_minLength_and_maxLength" {
 
 run "with_invalid_minLength_and_maxLength" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/string"
+  }
 
   variables {
     metadata_name = "test"
@@ -100,6 +112,9 @@ run "with_invalid_minLength_and_maxLength" {
 
 run "with_string_minLength" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/string"
+  }
 
   variables {
     metadata_name = "test"
@@ -118,6 +133,9 @@ run "with_string_minLength" {
 
 run "with_string_maxLength" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/string"
+  }
 
   variables {
     metadata_name = "test"
@@ -136,6 +154,9 @@ run "with_string_maxLength" {
 
 run "with_invalid_minLength_value" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/string"
+  }
 
   variables {
     metadata_name = "test"
@@ -154,6 +175,9 @@ run "with_invalid_minLength_value" {
 
 run "with_invalid_maxLength_value" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/string"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/CustomResourceDefinition_v1alpha1_version.tftest.hcl
+++ b/tests/CustomResourceDefinition_v1alpha1_version.tftest.hcl
@@ -1,5 +1,8 @@
 run "missing_name" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/version/"
+  }
 
   variables {
     metadata_name = "test"
@@ -15,6 +18,9 @@ run "missing_name" {
 
 run "missing_specSchema" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/version/"
+  }
 
   variables {
     metadata_name = "test"
@@ -32,6 +38,9 @@ run "missing_specSchema" {
 
 run "with_specSchema" {
   command = plan
+  module {
+    source = "./CustomResourceDefinition/v1alpha1/version/"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/manifestValidation.tftest.hcl
+++ b/tests/manifestValidation.tftest.hcl
@@ -1,5 +1,8 @@
 run "with_invalid_yaml" {
   command = plan
+  module {
+    source = "./manifestValidation/"
+  }
 
   variables {
     path = "."
@@ -13,6 +16,9 @@ run "with_invalid_yaml" {
 
 run "missing_apiVersion" {
   command = plan
+  module {
+    source = "./manifestValidation/"
+  }
 
   variables {
     path = "."
@@ -26,6 +32,9 @@ run "missing_apiVersion" {
 
 run "invalid_apiVersion" {
   command = plan
+  module {
+    source = "./manifestValidation/"
+  }
 
   variables {
     path = "."
@@ -41,6 +50,9 @@ run "invalid_apiVersion" {
 
 run "missing_kind" {
   command = plan
+  module {
+    source = "./manifestValidation/"
+  }
 
   variables {
     path = "."
@@ -56,6 +68,9 @@ run "missing_kind" {
 
 run "missing_metadata" {
   command = plan
+  module {
+    source = "./manifestValidation/"
+  }
 
   variables {
     path = "."
@@ -72,6 +87,9 @@ run "missing_metadata" {
 
 run "missing_metadata_name" {
   command = plan
+  module {
+    source = "./manifestValidation/"
+  }
 
   variables {
     path = "."
@@ -89,6 +107,9 @@ run "missing_metadata_name" {
 
 run "missing_spec" {
   command = plan
+  module {
+    source = "./manifestValidation/"
+  }
 
   variables {
     path = "."
@@ -107,6 +128,9 @@ run "missing_spec" {
 
 run "with_valid_manifest" {
   command = plan
+  module {
+    source = "./manifestValidation/"
+  }
 
   variables {
     path = "."

--- a/tests/resourceValidation.tftest.hcl
+++ b/tests/resourceValidation.tftest.hcl
@@ -1,5 +1,8 @@
 run "duplicated_custom_resource_definition" {
   command = plan
+  module {
+    source = "./resourceValidation/"
+  }
 
   variables {
     path = "."
@@ -82,6 +85,9 @@ run "duplicated_custom_resource_definition" {
 
 run "custom_resource_definition_not_found" {
   command = plan
+  module {
+    source = "./resourceValidation/"
+  }
 
   variables {
     path = "."
@@ -135,6 +141,9 @@ run "custom_resource_definition_not_found" {
 
 run "kind_not_found" {
   command = plan
+  module {
+    source = "./resourceValidation/"
+  }
 
   variables {
     path = "."
@@ -188,6 +197,9 @@ run "kind_not_found" {
 
 run "disabled_version" {
   command = plan
+  module {
+    source = "./resourceValidation/"
+  }
 
   variables {
     path = "."
@@ -241,6 +253,9 @@ run "disabled_version" {
 
 run "deprecated_version" {
   command = plan
+  module {
+    source = "./resourceValidation/"
+  }
 
   variables {
     path = "."
@@ -294,6 +309,9 @@ run "deprecated_version" {
 
 run "success" {
   command = plan
+  module {
+    source = "./resourceValidation/"
+  }
 
   variables {
     path = "."

--- a/tests/schemaValidation_array_v0.tftest.hcl
+++ b/tests/schemaValidation_array_v0.tftest.hcl
@@ -1,5 +1,8 @@
 run "missing_value" {
   command = plan
+  module {
+    source = "./schemaValidation/array/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -32,6 +35,9 @@ run "missing_value" {
 
 run "with_invalid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/array/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -64,6 +70,9 @@ run "with_invalid_value" {
 
 run "with_wrong_minItems" {
   command = plan
+  module {
+    source = "./schemaValidation/array/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -96,6 +105,9 @@ run "with_wrong_minItems" {
 
 run "with_wrong_maxItems" {
   command = plan
+  module {
+    source = "./schemaValidation/array/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -128,6 +140,9 @@ run "with_wrong_maxItems" {
 
 run "with_valid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/array/v0/"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/schemaValidation_bool_v0.tftest.hcl
+++ b/tests/schemaValidation_bool_v0.tftest.hcl
@@ -1,5 +1,8 @@
 run "missing_value" {
   command = plan
+  module {
+    source = "./schemaValidation/bool/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -21,6 +24,9 @@ run "missing_value" {
 
 run "with_invalid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/bool/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -42,6 +48,9 @@ run "with_invalid_value" {
 
 run "with_valid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/bool/v0/"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/schemaValidation_integer_v0.tftest.hcl
+++ b/tests/schemaValidation_integer_v0.tftest.hcl
@@ -1,5 +1,8 @@
 run "missing_value" {
   command = plan
+  module {
+    source = "./schemaValidation/integer/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -24,6 +27,9 @@ run "missing_value" {
 
 run "with_invalid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/integer/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -48,6 +54,9 @@ run "with_invalid_value" {
 
 run "with_wrong_minLegnth" {
   command = plan
+  module {
+    source = "./schemaValidation/integer/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -72,6 +81,9 @@ run "with_wrong_minLegnth" {
 
 run "with_wrong_maxLegnth" {
   command = plan
+  module {
+    source = "./schemaValidation/integer/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -97,6 +109,9 @@ run "with_wrong_maxLegnth" {
 
 run "with_valid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/integer/v0/"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/schemaValidation_object_v0.tftest.hcl
+++ b/tests/schemaValidation_object_v0.tftest.hcl
@@ -1,5 +1,8 @@
 run "missing_value" {
   command = plan
+  module {
+    source = "./schemaValidation/object/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -31,6 +34,9 @@ run "missing_value" {
 
 run "with_invalid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/object/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -62,6 +68,9 @@ run "with_invalid_value" {
 
 run "with_valid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/object/v0/"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/schemaValidation_reduced_array_v0.tftest.hcl
+++ b/tests/schemaValidation_reduced_array_v0.tftest.hcl
@@ -1,5 +1,8 @@
 run "missing_value" {
   command = plan
+  module {
+    source = "./schemaValidation/reduced_array/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -32,6 +35,9 @@ run "missing_value" {
 
 run "with_invalid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/reduced_array/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -64,6 +70,9 @@ run "with_invalid_value" {
 
 run "with_wrong_minItems" {
   command = plan
+  module {
+    source = "./schemaValidation/reduced_array/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -96,6 +105,9 @@ run "with_wrong_minItems" {
 
 run "with_wrong_maxItems" {
   command = plan
+  module {
+    source = "./schemaValidation/reduced_array/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -128,6 +140,9 @@ run "with_wrong_maxItems" {
 
 run "with_valid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/reduced_array/v0/"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/schemaValidation_reduced_object_v0.tftest.hcl
+++ b/tests/schemaValidation_reduced_object_v0.tftest.hcl
@@ -1,5 +1,8 @@
 run "missing_value" {
   command = plan
+  module {
+    source = "./schemaValidation/reduced_object/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -31,6 +34,9 @@ run "missing_value" {
 
 run "with_invalid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/reduced_object/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -62,6 +68,9 @@ run "with_invalid_value" {
 
 run "with_valid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/reduced_object/v0/"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/schemaValidation_root_object_v0.tftest.hcl
+++ b/tests/schemaValidation_root_object_v0.tftest.hcl
@@ -1,5 +1,8 @@
 run "missing_value" {
   command = plan
+  module {
+    source = "./schemaValidation/root_object/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -31,6 +34,9 @@ run "missing_value" {
 
 run "with_invalid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/root_object/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -62,6 +68,9 @@ run "with_invalid_value" {
 
 run "with_valid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/root_object/v0/"
+  }
 
   variables {
     metadata_name = "test"

--- a/tests/schemaValidation_string_v0.tftest.hcl
+++ b/tests/schemaValidation_string_v0.tftest.hcl
@@ -1,5 +1,8 @@
 run "missing_value" {
   command = plan
+  module {
+    source = "./schemaValidation/string/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -24,6 +27,9 @@ run "missing_value" {
 
 run "with_invalid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/string/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -48,6 +54,9 @@ run "with_invalid_value" {
 
 run "with_wrong_minLegnth" {
   command = plan
+  module {
+    source = "./schemaValidation/string/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -72,6 +81,9 @@ run "with_wrong_minLegnth" {
 
 run "with_wrong_maxLegnth" {
   command = plan
+  module {
+    source = "./schemaValidation/string/v0/"
+  }
 
   variables {
     metadata_name = "test"
@@ -97,6 +109,9 @@ run "with_wrong_maxLegnth" {
 
 run "with_valid_value" {
   command = plan
+  module {
+    source = "./schemaValidation/string/v0/"
+  }
 
   variables {
     metadata_name = "test"


### PR DESCRIPTION
Esse PR sugere uma mudança na localização dos testes do projeto.

Atualmente, como os testes estão em pastas espalhadas pelo projeto e o terraform não possui um "test runner" que consegue encontrar e rodar esses testes, precisamos de scripts adicionais para rodar a suite completa de testes.

Com essa mudança poderemos voltar a usar apenas `terraform test` para rodar toda a suite do projeto.

A nomenclatura sugeria é pegar o path do módulo sendo testado e colocar no nome do arquivo, sess forma podemos usar fuzzy find para encontrar rapidamente os testes do modulo desejado.

Nesse caso o módulo `CustomResourceDefinition/v1alpha1/` tem seus testes no arquivo `tests/CustomResourceDefinition_v1alpha1.tftest.hcl`.

Exemplo de como fica o output:
```
❯ t test                                                                                                              3m22s 
tests/CustomResourceDefinition_v1alpha1.tftest.hcl... in progress
  run "missing_group"... pass
  run "missing_kind"... pass
  run "missing_versions"... pass
  run "with_invalid_versions"... pass
  run "with_valid_versions"... pass
tests/CustomResourceDefinition_v1alpha1.tftest.hcl... tearing down
tests/CustomResourceDefinition_v1alpha1.tftest.hcl... pass
tests/test_crd_with_multiple_versions.tftest.hcl... in progress
  run "parse_crd_with_multiple_versions"... pass
tests/test_crd_with_multiple_versions.tftest.hcl... tearing down
tests/test_crd_with_multiple_versions.tftest.hcl... pass
tests/test_output_by_apigroup.tftest.hcl... in progress
  run "valida_output_por_apigroup"... pass
  run "valida_output_por_kind"... pass
tests/test_output_by_apigroup.tftest.hcl... tearing down
tests/test_output_by_apigroup.tftest.hcl... pass
tests/test_parse_manifest_with_v1alpha1_crd_full_fields.tftest.hcl... in progress
  run "parse_manifest_crd_v1alpha1_full_fields"... pass
tests/test_parse_manifest_with_v1alpha1_crd_full_fields.tftest.hcl... tearing down
tests/test_parse_manifest_with_v1alpha1_crd_full_fields.tftest.hcl... pass

Success! 9 passed, 0 failed.
```
