### PR TITLE
Possível bug para campos multi-version

### DIFF
--- a/schemaValidation/bool/main.tf
+++ b/schemaValidation/bool/main.tf
@@ -9,6 +9,20 @@ module "v0" {
   schema        = var.schema
 }
 
+module "v1" {
+  source = "./v1"
+  count  = var.schema.version == "v1" ? 1 : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = var.field_path
+  manifest      = var.manifest
+  schema        = var.schema
+}
+
 output "resource" {
-  value = one(module.v0[*].resource)
+  value = one(
+    module.v0[*].resource,
+    module.v1[*].resource,
+  )
 }

--- a/schemaValidation/bool/main.tf
+++ b/schemaValidation/bool/main.tf
@@ -22,7 +22,9 @@ module "v1" {
 
 output "resource" {
   value = one(
-    module.v0[*].resource,
-    module.v1[*].resource,
+    concat(
+      module.v0[*].resource,
+      module.v1[*].resource,
+    )
   )
 }

--- a/schemaValidation/bool/v1/main.tf
+++ b/schemaValidation/bool/v1/main.tf
@@ -1,0 +1,21 @@
+output "resource" {
+  value = try(tobool(var.manifest), null)
+
+  precondition {
+    condition     = var.manifest != null
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The property "${var.field_path}" can not be null.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = can(tobool(var.manifest))
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The type of the property "${var.field_path}" must be bool.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+}

--- a/schemaValidation/bool/v1/variables.tf
+++ b/schemaValidation/bool/v1/variables.tf
@@ -1,0 +1,19 @@
+variable "metadata_name" {
+  type = string
+}
+
+variable "path" {
+  type = string
+}
+
+variable "field_path" {
+  type = string
+}
+
+variable "manifest" {
+  type = any
+}
+
+variable "schema" {
+  type = any
+}

--- a/tests/schemaValidation_bool.tftest.hcl
+++ b/tests/schemaValidation_bool.tftest.hcl
@@ -1,0 +1,57 @@
+run "check_can_validate_bool_v0" {
+  command = plan
+  module {
+    source = "./schemaValidation/bool"
+  }
+
+
+  variables {
+    metadata_name = "teste-manifest"
+    path          = "."
+    field_path    = "spec.teste"
+    manifest      = true
+
+    schema = {
+      type        = "bool"
+      version     = "v0"
+      subItem     = null
+      validations = {}
+    }
+  }
+
+
+  assert {
+    condition = output.resource == true
+
+    error_message = "Não validou campo bool v0"
+  }
+}
+
+run "check_can_validate_bool_v1" {
+  command = plan
+  module {
+    source = "./schemaValidation/bool"
+  }
+
+  variables {
+    metadata_name = "teste-manifest"
+    path          = "."
+    field_path    = "spec.teste"
+    manifest      = true
+
+    schema = {
+      type        = "bool"
+      version     = "v1"
+      subItem     = null
+      validations = {}
+    }
+  }
+
+
+  assert {
+    condition = output.resource == true
+
+    error_message = "Não validou campo bool v1. output.resource = ${format("%v", output.resource)}"
+  }
+
+}


### PR DESCRIPTION
Durante a implementação (ainda inacabada) do default value para campos boolean (#16) percebi que quando temos mútiplas versões de uma property dentro do `schemaValidation`, apesar de termos já a estrutra para podermos selecionar qual versão será usada, o terraform retorna um erro.

Esse erro tem relação com os parametros que estão sendo passados para a function [one()](https://developer.hashicorp.com/terraform/language/functions/one).

Quando apenas passamos dessa forma:
```terraform
output "resource" {
  value = one(
      module.v0[*].resource,
      module.v1[*].resource,
  )
}
```
vemos o erro abaixo:
![Captura de tela de 2024-10-15 13-13-15](https://github.com/user-attachments/assets/bbd0f59f-9add-4b69-8e98-192e9132d475)

Isso porque, no final, o que é passado para a function `one()` são dois parametros: `one([], [true])`. Aqui o exemplo é do caso do bool que retorna apenas um `true` ou `false`. Como uma das versões não será usada a expansão `[*].resource` retorna uma lista vazia (`[]`).

A Correção (que quero confirmar que está ok e se sim vou seguir com ela na implementação do #16) está feita no commit: 36cf01e75e9554caae7fc5e876c01bd4d2d52b1e.

```diff
diff --git a/schemaValidation/bool/main.tf b/schemaValidation/bool/main.tf
index 59f72e5..a7fffe9 100644
--- a/schemaValidation/bool/main.tf
+++ b/schemaValidation/bool/main.tf
@@ -22,7 +22,9 @@ module "v1" {
 
 output "resource" {
   value = one(
-    module.v0[*].resource,
-    module.v1[*].resource,
+    concat(
+      module.v0[*].resource,
+      module.v1[*].resource,
+    )
   )
 }
```

O que fazemos é apenas um `concat()` antes de chamar o `one()`, dessa forma teremos novamente apenas um parametro e isso tornará a chamada do `one()` válida.

Abaixo está um exemplo no terraform console:
```
t console
> concat([], [true])
[
  true,
]
> one(concat([], [true]))
true
>  
```

Com essa abordagem os testes passam quando temos múltiplas versões de uma mesma property:
![Captura de tela de 2024-10-15 13-19-01](https://github.com/user-attachments/assets/487721d5-d8ff-4369-bb67-9a8b12971f3a)


Esse PR não precisa ser mergeado, ele serve apenas para demonstrar o problema e discutir a solução que será seguida no fix. ❤️ 
